### PR TITLE
fix: 修复白名单文件夹配置不生效问题，补充校验以改进安全性

### DIFF
--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -81,9 +81,15 @@ impl Default for ScanConfig {
     }
 }
 
-fn default_scan_batch_size() -> usize { 1000 }
-fn default_max_pending_tasks() -> usize { 5000 }
-fn default_progress_interval() -> usize { 500 }
+fn default_scan_batch_size() -> usize {
+    1000
+}
+fn default_max_pending_tasks() -> usize {
+    5000
+}
+fn default_progress_interval() -> usize {
+    500
+}
 
 /// 冲突策略配置
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -101,7 +107,8 @@ impl Default for ConflictStrategyConfig {
     fn default() -> Self {
         Self {
             default_upload_strategy: crate::uploader::conflict::UploadConflictStrategy::SmartDedup,
-            default_download_strategy: crate::uploader::conflict::DownloadConflictStrategy::Overwrite,
+            default_download_strategy:
+                crate::uploader::conflict::DownloadConflictStrategy::Overwrite,
         }
     }
 }
@@ -671,6 +678,9 @@ pub struct FilesystemConfig {
     /// 允许访问的路径白名单（空表示允许所有）
     #[serde(default)]
     pub allowed_paths: Vec<String>,
+    /// 上传弹窗默认优先展示的白名单目录
+    #[serde(default)]
+    pub default_path: Option<String>,
     /// 是否显示隐藏文件
     #[serde(default)]
     pub show_hidden: bool,
@@ -683,6 +693,7 @@ impl Default for FilesystemConfig {
     fn default() -> Self {
         Self {
             allowed_paths: vec![],
+            default_path: None,
             show_hidden: false,
             follow_symlinks: false,
         }
@@ -1546,8 +1557,8 @@ mod tests {
 
     // ========== 冲突策略配置测试 ==========
 
+    use crate::uploader::conflict::{DownloadConflictStrategy, UploadConflictStrategy};
     use proptest::prelude::*;
-    use crate::uploader::conflict::{UploadConflictStrategy, DownloadConflictStrategy};
 
     // 生成器：上传冲突策略
     fn prop_upload_strategy() -> impl Strategy<Value = UploadConflictStrategy> {
@@ -1687,4 +1698,3 @@ ask_each_time = true
         assert!(toml_str.contains("overwrite"));
     }
 }
-

--- a/backend/src/filesystem/guard.rs
+++ b/backend/src/filesystem/guard.rs
@@ -18,6 +18,44 @@ impl PathGuard {
         Self { config }
     }
 
+    /// 白名单是否已启用
+    pub fn has_allowed_paths(&self) -> bool {
+        !self.config.allowed_paths.is_empty()
+    }
+
+    /// 解析并排序根目录列表。
+    ///
+    /// 当配置了 default_path 时，会优先放到返回列表第一位。
+    pub fn resolve_allowed_roots(&self) -> Result<Vec<PathBuf>, FsError> {
+        let mut roots = Vec::new();
+
+        for allowed in &self.config.allowed_paths {
+            let canonical = self.normalize_existing_directory(allowed)?;
+            Self::push_unique_path(&mut roots, canonical);
+        }
+
+        if let Some(default_path) = self.resolve_default_directory()? {
+            roots.retain(|path| path != &default_path);
+            roots.insert(0, default_path);
+        }
+
+        Ok(roots)
+    }
+
+    /// 解析默认目录，并校验其处于白名单范围内。
+    pub fn resolve_default_directory(&self) -> Result<Option<PathBuf>, FsError> {
+        let Some(default_path) = self.config.default_path.as_deref() else {
+            return Ok(None);
+        };
+
+        let canonical = self.normalize_existing_directory(default_path)?;
+        if self.has_allowed_paths() && !self.is_allowed(&canonical) {
+            return Err(FsError::new(FsErrorCode::PathNotAllowed).with_path(default_path));
+        }
+
+        Ok(Some(canonical))
+    }
+
     /// 检查路径是否在白名单内
     ///
     /// 如果白名单为空，表示允许所有路径
@@ -136,6 +174,25 @@ impl PathGuard {
         self.is_symlink(path)
     }
 
+    /// 将目录路径规范化为已存在的绝对目录
+    fn normalize_existing_directory(&self, path: &str) -> Result<PathBuf, FsError> {
+        let canonical = PathBuf::from(path)
+            .canonicalize()
+            .map_err(|_| FsError::new(FsErrorCode::DirectoryNotFound).with_path(path))?;
+
+        if !canonical.is_dir() {
+            return Err(FsError::new(FsErrorCode::NotADirectory).with_path(path));
+        }
+
+        Ok(canonical)
+    }
+
+    fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+        if !paths.iter().any(|existing| existing == &path) {
+            paths.push(path);
+        }
+    }
+
     /// 检查路径是否包含穿越序列
     fn contains_traversal(&self, path: &str) -> bool {
         // 检查常见的穿越模式
@@ -203,5 +260,27 @@ mod tests {
         // 当 show_hidden = true 时，不应该隐藏任何文件
         assert!(!guard.is_hidden(Path::new("/home/user/.bashrc")));
         assert!(!guard.is_hidden(Path::new(".gitignore")));
+    }
+
+    #[test]
+    fn test_resolve_allowed_roots_prioritizes_default_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let primary = temp_dir.path().join("primary");
+        let secondary = temp_dir.path().join("secondary");
+        std::fs::create_dir_all(&primary).unwrap();
+        std::fs::create_dir_all(&secondary).unwrap();
+
+        let guard = PathGuard::new(FilesystemConfig {
+            allowed_paths: vec![
+                primary.to_string_lossy().to_string(),
+                secondary.to_string_lossy().to_string(),
+            ],
+            default_path: Some(secondary.to_string_lossy().to_string()),
+            ..Default::default()
+        });
+
+        let roots = guard.resolve_allowed_roots().unwrap();
+        assert_eq!(roots[0], secondary.canonicalize().unwrap());
+        assert_eq!(roots.len(), 2);
     }
 }

--- a/backend/src/filesystem/service.rs
+++ b/backend/src/filesystem/service.rs
@@ -248,8 +248,12 @@ impl FilesystemService {
         })
     }
 
-    /// 获取根目录列表（Windows 驱动器列表 / Unix 根目录）
+    /// 获取根目录列表（Windows 驱动器列表 / Unix 根目录 / 白名单目录）
     pub fn get_roots(&self) -> Result<Vec<FileEntry>, FsError> {
+        if self.guard.has_allowed_paths() {
+            return self.get_allowed_roots();
+        }
+
         #[cfg(target_os = "windows")]
         {
             self.get_windows_drives()
@@ -259,6 +263,14 @@ impl FilesystemService {
         {
             self.get_unix_roots()
         }
+    }
+
+    fn get_allowed_roots(&self) -> Result<Vec<FileEntry>, FsError> {
+        self.guard
+            .resolve_allowed_roots()?
+            .into_iter()
+            .map(|path| self.create_root_entry(&path))
+            .collect()
     }
 
     /// Windows: 获取驱动器列表
@@ -366,9 +378,22 @@ impl FilesystemService {
         Ok(entries)
     }
 
-    /// 创建挂载点条目
-    #[cfg(not(target_os = "windows"))]
-    fn create_mount_entry(&self, path: &PathBuf, display_name: &str) -> Result<FileEntry, FsError> {
+    /// 创建根目录/挂载点条目
+    fn create_root_entry(&self, path: &Path) -> Result<FileEntry, FsError> {
+        let name = path
+            .file_name()
+            .map(|value| value.to_string_lossy().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| path.to_string_lossy().to_string());
+
+        self.create_directory_entry(path, name)
+    }
+
+    fn create_directory_entry(
+        &self,
+        path: &Path,
+        name: impl Into<String>,
+    ) -> Result<FileEntry, FsError> {
         let metadata = fs::metadata(path).map_err(|_| {
             FsError::new(FsErrorCode::DirectoryReadFailed)
                 .with_path(path.to_string_lossy().to_string())
@@ -388,7 +413,7 @@ impl FilesystemService {
 
         Ok(FileEntry {
             id: self.path_to_id(path),
-            name: display_name.to_string(),
+            name: name.into(),
             entry_type: EntryType::Directory,
             size: None,
             created_at,
@@ -396,6 +421,12 @@ impl FilesystemService {
             icon: Some("drive".to_string()),
             path: path.to_string_lossy().to_string(),
         })
+    }
+
+    /// 创建挂载点条目
+    #[cfg(not(target_os = "windows"))]
+    fn create_mount_entry(&self, path: &PathBuf, display_name: &str) -> Result<FileEntry, FsError> {
+        self.create_directory_entry(path, display_name.to_string())
     }
 
     /// 将 DirEntry 转换为 FileEntry
@@ -526,6 +557,35 @@ mod tests {
             assert_eq!(roots.len(), 1);
             assert_eq!(roots[0].path, "/");
         }
+    }
+
+    #[test]
+    fn test_get_roots_uses_allowed_paths_and_prioritizes_default_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let alpha = temp_dir.path().join("alpha");
+        let beta = temp_dir.path().join("beta");
+        std::fs::create_dir_all(&alpha).unwrap();
+        std::fs::create_dir_all(&beta).unwrap();
+
+        let service = FilesystemService::new(FilesystemConfig {
+            allowed_paths: vec![
+                alpha.to_string_lossy().to_string(),
+                beta.to_string_lossy().to_string(),
+            ],
+            default_path: Some(beta.to_string_lossy().to_string()),
+            ..Default::default()
+        });
+
+        let roots = service.get_roots().unwrap();
+        assert_eq!(roots.len(), 2);
+        assert_eq!(
+            roots[0].path,
+            beta.canonicalize().unwrap().to_string_lossy()
+        );
+        assert_eq!(
+            roots[1].path,
+            alpha.canonicalize().unwrap().to_string_lossy()
+        );
     }
 
     #[test]

--- a/backend/src/server/handlers/filesystem.rs
+++ b/backend/src/server/handlers/filesystem.rs
@@ -52,18 +52,17 @@ impl IntoResponse for FsError {
 }
 
 /// 创建文件系统服务
-fn create_fs_service() -> FilesystemService {
-    // TODO: 从配置读取 FilesystemConfig
-    FilesystemService::new(FilesystemConfig::default())
+fn create_fs_service(config: FilesystemConfig) -> FilesystemService {
+    FilesystemService::new(config)
 }
 
 /// GET /api/v1/fs/list?path=/&page=0&page_size=100&sort_field=name&sort_order=asc
 /// 列出目录内容（支持分页）
 pub async fn list_directory(
-    State(_app_state): State<AppState>,
+    State(app_state): State<AppState>,
     Query(req): Query<ListRequest>,
 ) -> Result<Json<ApiResponse<ListResponse>>, FsError> {
-    let service = create_fs_service();
+    let service = create_fs_service(app_state.config.read().await.filesystem.clone());
     let response = service.list_directory(&req)?;
     Ok(Json(ApiResponse::success(response)))
 }
@@ -71,10 +70,10 @@ pub async fn list_directory(
 /// GET /api/v1/fs/goto?path=/home/user/documents
 /// 路径跳转（直达路径）
 pub async fn goto_path(
-    State(_app_state): State<AppState>,
+    State(app_state): State<AppState>,
     Query(req): Query<GotoRequest>,
 ) -> Json<ApiResponse<GotoResponse>> {
-    let service = create_fs_service();
+    let service = create_fs_service(app_state.config.read().await.filesystem.clone());
     let response = service.goto_path(&req);
     Json(ApiResponse::success(response))
 }
@@ -82,10 +81,10 @@ pub async fn goto_path(
 /// GET /api/v1/fs/validate?path=/xxx&type=file
 /// 校验路径有效性
 pub async fn validate_path(
-    State(_app_state): State<AppState>,
+    State(app_state): State<AppState>,
     Query(req): Query<ValidateRequest>,
 ) -> Json<ApiResponse<ValidateResponse>> {
-    let service = create_fs_service();
+    let service = create_fs_service(app_state.config.read().await.filesystem.clone());
     let response = service.validate_path(&req);
     Json(ApiResponse::success(response))
 }
@@ -93,9 +92,9 @@ pub async fn validate_path(
 /// GET /api/v1/fs/roots
 /// 获取根目录列表
 pub async fn get_roots(
-    State(_app_state): State<AppState>,
+    State(app_state): State<AppState>,
 ) -> Result<Json<ApiResponse<Vec<FileEntry>>>, FsError> {
-    let service = create_fs_service();
+    let service = create_fs_service(app_state.config.read().await.filesystem.clone());
     let roots = service.get_roots()?;
     Ok(Json(ApiResponse::success(roots)))
 }

--- a/backend/src/server/handlers/upload.rs
+++ b/backend/src/server/handlers/upload.rs
@@ -1,3 +1,5 @@
+use crate::filesystem::{FilesystemConfig, PathGuard};
+use crate::server::error::{ApiError, ApiResult};
 use crate::server::AppState;
 use crate::uploader::{ScanOptions, ScanTaskStatus, UploadConflictStrategy, UploadTask};
 use axum::{
@@ -63,6 +65,40 @@ fn default_skip_hidden() -> bool {
     true
 }
 
+fn create_path_guard(config: &FilesystemConfig) -> PathGuard {
+    PathGuard::new(config.clone())
+}
+
+fn validate_upload_file_path(guard: &PathGuard, path: &str) -> Result<PathBuf, ApiError> {
+    let normalized = guard
+        .normalize(path)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    if !normalized.is_file() {
+        return Err(ApiError::BadRequest(format!(
+            "上传源文件不存在或不是文件: {}",
+            path
+        )));
+    }
+
+    Ok(normalized)
+}
+
+fn validate_upload_directory_path(guard: &PathGuard, path: &str) -> Result<PathBuf, ApiError> {
+    let normalized = guard
+        .normalize(path)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    if !normalized.is_dir() {
+        return Err(ApiError::BadRequest(format!(
+            "上传源目录不存在或不是目录: {}",
+            path
+        )));
+    }
+
+    Ok(normalized)
+}
+
 impl From<FolderScanOptions> for ScanOptions {
     fn from(options: FolderScanOptions) -> Self {
         Self {
@@ -109,26 +145,35 @@ pub struct ScanStatusResponse {
 pub async fn create_upload(
     State(app_state): State<AppState>,
     Json(req): Json<CreateUploadRequest>,
-) -> Result<Json<ApiResponse<String>>, StatusCode> {
+) -> ApiResult<Json<ApiResponse<String>>> {
     // 获取上传管理器
     let upload_manager = app_state
         .upload_manager
         .read()
         .await
         .clone()
-        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+        .ok_or_else(|| ApiError::Internal(anyhow::anyhow!("上传管理器未初始化")))?;
+
+    let config = app_state.config.read().await;
+    let guard = create_path_guard(&config.filesystem);
 
     // 如果未指定策略，从 AppConfig 读取默认值
-    let conflict_strategy = req.conflict_strategy.or_else(|| {
-        let config = app_state.config.blocking_read();
-        Some(config.conflict_strategy.default_upload_strategy)
-    });
+    let conflict_strategy = req
+        .conflict_strategy
+        .or(Some(config.conflict_strategy.default_upload_strategy));
 
-    let local_path = PathBuf::from(&req.local_path);
+    let local_path = validate_upload_file_path(&guard, &req.local_path)?;
+    drop(config);
 
     // 🔥 传递 encrypt 参数，普通文件上传 is_folder_upload = false
     match upload_manager
-        .create_task(local_path, req.remote_path, req.encrypt, false, conflict_strategy)
+        .create_task(
+            local_path,
+            req.remote_path,
+            req.encrypt,
+            false,
+            conflict_strategy,
+        )
         .await
     {
         Ok(task_id) => {
@@ -143,7 +188,7 @@ pub async fn create_upload(
         }
         Err(e) => {
             error!("创建上传任务失败: {:?}", e);
-            Err(StatusCode::INTERNAL_SERVER_ERROR)
+            Err(ApiError::Internal(anyhow::anyhow!(e.to_string())))
         }
     }
 }
@@ -153,23 +198,26 @@ pub async fn create_upload(
 pub async fn create_folder_upload(
     State(app_state): State<AppState>,
     Json(req): Json<CreateFolderUploadRequest>,
-) -> Result<Json<ApiResponse<ScanStartResponse>>, StatusCode> {
+) -> ApiResult<Json<ApiResponse<ScanStartResponse>>> {
     // 获取扫描管理器
     let scan_manager = app_state
         .scan_manager
         .read()
         .await
         .clone()
-        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+        .ok_or_else(|| ApiError::Internal(anyhow::anyhow!("扫描管理器未初始化")))?;
 
     // 获取配置
     let config = app_state.config.read().await;
+    let guard = create_path_guard(&config.filesystem);
     let skip_hidden_files = config.upload.skip_hidden_files;
     // 如果未指定策略，从 AppConfig 读取默认值
-    let conflict_strategy = req.conflict_strategy.or(Some(config.conflict_strategy.default_upload_strategy));
-    drop(config);
+    let conflict_strategy = req
+        .conflict_strategy
+        .or(Some(config.conflict_strategy.default_upload_strategy));
 
-    let local_folder = PathBuf::from(&req.local_folder);
+    let local_folder = validate_upload_directory_path(&guard, &req.local_folder)?;
+    drop(config);
 
     let scan_options = if let Some(opts) = req.scan_options {
         Some(opts.into())
@@ -181,16 +229,27 @@ pub async fn create_folder_upload(
     };
 
     match scan_manager
-        .start_scan(local_folder, req.remote_folder, scan_options, req.encrypt, conflict_strategy)
+        .start_scan(
+            local_folder,
+            req.remote_folder,
+            scan_options,
+            req.encrypt,
+            conflict_strategy,
+        )
         .await
     {
         Ok(scan_task_id) => {
-            info!("文件夹扫描任务已启动: {} (encrypt={})", scan_task_id, req.encrypt);
-            Ok(Json(ApiResponse::success(ScanStartResponse { scan_task_id })))
+            info!(
+                "文件夹扫描任务已启动: {} (encrypt={})",
+                scan_task_id, req.encrypt
+            );
+            Ok(Json(ApiResponse::success(ScanStartResponse {
+                scan_task_id,
+            })))
         }
         Err(e) => {
             error!("启动文件夹扫描失败: {:?}", e);
-            Err(StatusCode::INTERNAL_SERVER_ERROR)
+            Err(ApiError::Internal(anyhow::anyhow!(e.to_string())))
         }
     }
 }
@@ -200,32 +259,42 @@ pub async fn create_folder_upload(
 pub async fn create_batch_upload(
     State(app_state): State<AppState>,
     Json(req): Json<CreateBatchUploadRequest>,
-) -> Result<Json<ApiResponse<Vec<String>>>, StatusCode> {
+) -> ApiResult<Json<ApiResponse<Vec<String>>>> {
     // 获取上传管理器
     let upload_manager = app_state
         .upload_manager
         .read()
         .await
         .clone()
-        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+        .ok_or_else(|| ApiError::Internal(anyhow::anyhow!("上传管理器未初始化")))?;
+
+    let config = app_state.config.read().await;
+    let guard = create_path_guard(&config.filesystem);
 
     // 如果未指定策略，从 AppConfig 读取默认值
-    let conflict_strategy = req.conflict_strategy.or_else(|| {
-        let config = app_state.config.blocking_read();
-        Some(config.conflict_strategy.default_upload_strategy)
-    });
+    let conflict_strategy = req
+        .conflict_strategy
+        .or(Some(config.conflict_strategy.default_upload_strategy));
 
-    // 转换为 PathBuf
+    // 转换为 PathBuf，并补充白名单校验
     let files: Vec<(PathBuf, String)> = req
         .files
         .into_iter()
-        .map(|(local, remote)| (PathBuf::from(local), remote))
-        .collect();
+        .map(|(local, remote)| validate_upload_file_path(&guard, &local).map(|path| (path, remote)))
+        .collect::<Result<Vec<_>, _>>()?;
+    drop(config);
 
     // 🔥 传递 encrypt 参数
-    match upload_manager.create_batch_tasks(files, req.encrypt, conflict_strategy).await {
+    match upload_manager
+        .create_batch_tasks(files, req.encrypt, conflict_strategy)
+        .await
+    {
         Ok(task_ids) => {
-            info!("批量创建上传任务成功: {} 个 (encrypt={})", task_ids.len(), req.encrypt);
+            info!(
+                "批量创建上传任务成功: {} 个 (encrypt={})",
+                task_ids.len(),
+                req.encrypt
+            );
 
             // 自动开始所有任务
             for task_id in &task_ids {
@@ -238,7 +307,7 @@ pub async fn create_batch_upload(
         }
         Err(e) => {
             error!("批量创建上传任务失败: {:?}", e);
-            Err(StatusCode::INTERNAL_SERVER_ERROR)
+            Err(ApiError::Internal(anyhow::anyhow!(e.to_string())))
         }
     }
 }
@@ -448,14 +517,18 @@ pub async fn cancel_scan(
 
 // ==================== 批量操作 ====================
 
-use super::common::{BatchOperationRequest, BatchOperationItem, BatchOperationResponse};
+use super::common::{BatchOperationItem, BatchOperationRequest, BatchOperationResponse};
 
 /// POST /api/v1/uploads/batch/pause
 pub async fn batch_pause_uploads(
     State(app_state): State<AppState>,
     Json(req): Json<BatchOperationRequest>,
 ) -> Result<Json<ApiResponse<BatchOperationResponse>>, StatusCode> {
-    let mgr = app_state.upload_manager.read().await.clone()
+    let mgr = app_state
+        .upload_manager
+        .read()
+        .await
+        .clone()
         .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let ids = if req.all == Some(true) {
@@ -465,10 +538,17 @@ pub async fn batch_pause_uploads(
     };
 
     let raw = mgr.batch_pause(&ids).await;
-    let results: Vec<BatchOperationItem> = raw.into_iter()
-        .map(|(id, ok, err)| BatchOperationItem { task_id: id, success: ok, error: err })
+    let results: Vec<BatchOperationItem> = raw
+        .into_iter()
+        .map(|(id, ok, err)| BatchOperationItem {
+            task_id: id,
+            success: ok,
+            error: err,
+        })
         .collect();
-    Ok(Json(ApiResponse::success(BatchOperationResponse::from_results(results))))
+    Ok(Json(ApiResponse::success(
+        BatchOperationResponse::from_results(results),
+    )))
 }
 
 /// POST /api/v1/uploads/batch/resume
@@ -476,7 +556,11 @@ pub async fn batch_resume_uploads(
     State(app_state): State<AppState>,
     Json(req): Json<BatchOperationRequest>,
 ) -> Result<Json<ApiResponse<BatchOperationResponse>>, StatusCode> {
-    let mgr = app_state.upload_manager.read().await.clone()
+    let mgr = app_state
+        .upload_manager
+        .read()
+        .await
+        .clone()
         .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let ids = if req.all == Some(true) {
@@ -486,10 +570,17 @@ pub async fn batch_resume_uploads(
     };
 
     let raw = mgr.batch_resume(&ids).await;
-    let results: Vec<BatchOperationItem> = raw.into_iter()
-        .map(|(id, ok, err)| BatchOperationItem { task_id: id, success: ok, error: err })
+    let results: Vec<BatchOperationItem> = raw
+        .into_iter()
+        .map(|(id, ok, err)| BatchOperationItem {
+            task_id: id,
+            success: ok,
+            error: err,
+        })
         .collect();
-    Ok(Json(ApiResponse::success(BatchOperationResponse::from_results(results))))
+    Ok(Json(ApiResponse::success(
+        BatchOperationResponse::from_results(results),
+    )))
 }
 
 /// POST /api/v1/uploads/batch/delete
@@ -497,7 +588,11 @@ pub async fn batch_delete_uploads(
     State(app_state): State<AppState>,
     Json(req): Json<BatchOperationRequest>,
 ) -> Result<Json<ApiResponse<BatchOperationResponse>>, StatusCode> {
-    let mgr = app_state.upload_manager.read().await.clone()
+    let mgr = app_state
+        .upload_manager
+        .read()
+        .await
+        .clone()
         .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let ids = if req.all == Some(true) {
@@ -507,8 +602,15 @@ pub async fn batch_delete_uploads(
     };
 
     let raw = mgr.batch_delete(&ids).await;
-    let results: Vec<BatchOperationItem> = raw.into_iter()
-        .map(|(id, ok, err)| BatchOperationItem { task_id: id, success: ok, error: err })
+    let results: Vec<BatchOperationItem> = raw
+        .into_iter()
+        .map(|(id, ok, err)| BatchOperationItem {
+            task_id: id,
+            success: ok,
+            error: err,
+        })
         .collect();
-    Ok(Json(ApiResponse::success(BatchOperationResponse::from_results(results))))
+    Ok(Json(ApiResponse::success(
+        BatchOperationResponse::from_results(results),
+    )))
 }

--- a/config/app.toml.example
+++ b/config/app.toml.example
@@ -24,6 +24,20 @@ chunk_size_mb = 10
 # 下载失败后的最大重试次数
 max_retries = 3
 
+
+[filesystem]
+# 允许上传选择器访问的本地白名单目录（空数组表示不限制）
+allowed_paths = ["/data/uploads", "/data/media"]
+
+# 上传弹窗默认优先展示的白名单目录（需位于 allowed_paths 范围内）
+default_path = "/data/uploads"
+
+# 是否显示隐藏文件
+show_hidden = false
+
+# 是否跟随符号链接
+follow_symlinks = false
+
 # Web 访问认证配置
 # 用于保护部署在公网 VPS 上的管理界面
 [web_auth]

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -77,6 +77,7 @@ export interface TransferConfig {
 /// 文件系统配置
 export interface FilesystemConfig {
   allowed_paths?: string[]
+  default_path?: string
   show_hidden?: boolean
   follow_symlinks?: boolean
 }


### PR DESCRIPTION

### 问题

API 层创建 `FilesystemService` 时没从 `app.toml` 读取白名单文件夹配置，而是每次都 `FilesystemConfig::default()`（读取默认配置），所以写在配置文件里的白名单配置不会生效。

### 修复说明

修复了原本存在的白名单文件夹配置不生效问题。现在在 `app.toml` 中可以指定程序可以访问的文件夹，并通过修改配置文件指定每次打开文件选择窗口时默认展示的文件夹。

### 具体改动

1. 修复了 `filesystem` 配置未从 `app.toml` 注入 API 层的问题；
2. 扩展了 `PathGuard`，补上了“默认白名单目录”所需的辅助逻辑；
3. 调整了 `FilesystemService::get_roots()` 实现：
   - 当 `allowed_paths` 非空时，根列表直接返回白名单目录，而不是盘符；
   - 如果配置了 `default_path`，传输弹窗首次打开时优先展示默认白名单目录；
4. 在上传入口补上了后端白名单校验：
   - 单文件上传、文件夹上传、批量上传都会先用 `PathGuard` 规范化并校验本地路径
5. 补充了示例配置中的 `[filesystem]` 段。