### PR TITLE
fix: 修复转存路径包含分享者原始目录结构的问题

### DIFF
--- a/backend/src/transfer/manager.rs
+++ b/backend/src/transfer/manager.rs
@@ -3859,21 +3859,35 @@ fn detect_cross_dir_duplicates(files: &[SharedFileInfo]) -> Vec<String> {
         .collect()
 }
 
-/// 推导分享链接的虚拟根路径，用于计算文件的相对目录结构。
+/// 推导分享文件的公共父目录，用于计算文件的相对目录结构。
 ///
-/// 分享文件路径格式: `/sharelink{share_id}-{uk}/实际目录/文件名`
-/// 第一段 `/sharelink...` 是虚拟命名空间，后续路径是用户原始的目录结构，应完整保留。
-/// 因此 share_root 取第一个路径段，而非最长公共前缀（后者会吃掉中间层级）。
+/// 取所有文件路径的最长公共父目录。例如：
+/// - 单文件 `/a/b/c/file.mp4` → share_root = `/a/b/c`
+/// - 多文件 `/root/抖音/1.jpg`, `/root/微信/2.jpg` → share_root = `/root`
+/// - `/sharelink123/dir/file` → share_root = `/sharelink123/dir`
 fn infer_share_root(files: &[SharedFileInfo]) -> String {
     if files.is_empty() {
         return String::new();
     }
-    let first_path = &files[0].path;
-    let segments: Vec<&str> = first_path.split('/').filter(|s| !s.is_empty()).collect();
-    if segments.is_empty() {
-        return String::new();
+    let parents: Vec<&str> = files.iter().map(|f| extract_parent_dir_str(&f.path)).collect();
+    let first_segs: Vec<&str> = parents[0].split('/').collect();
+    let mut common_len = first_segs.len();
+    for p in &parents[1..] {
+        let segs: Vec<&str> = p.split('/').collect();
+        common_len = common_len.min(segs.len());
+        for i in 0..common_len {
+            if first_segs[i] != segs[i] {
+                common_len = i;
+                break;
+            }
+        }
     }
-    format!("/{}", segments[0])
+    let common: String = first_segs[..common_len].join("/");
+    if common.is_empty() || common == "/" {
+        String::new()
+    } else {
+        common
+    }
 }
 
 /// 按原始父目录分组文件，保留分享链接中的目录结构。
@@ -4139,11 +4153,10 @@ mod tests {
             make_file("/root/a/3.jpg", 3),
         ];
         let share_root = infer_share_root(&files);
-        // share_root = "/root"（第一路径段），relative_parent = "a"
-        assert_eq!(share_root, "/root");
+        assert_eq!(share_root, "/root/a");
         let groups = group_files_by_parent_dir(&files, &share_root);
         assert_eq!(groups.len(), 1, "同目录文件应只有 1 个组");
-        assert_eq!(groups[0].0, "a");
+        assert_eq!(groups[0].0, "");
         assert_eq!(groups[0].1.len(), 3);
     }
 


### PR DESCRIPTION
## 问题描述

转存分享链接时，目标路径会错误地包含分享者的原始目录结构。

### 复现示例

分享链接 `https://pan.baidu.com/s/1F56jz8a8B8BPQZJs68RNhw?pwd=6666`，分享的根目录内容是 `BBC.恐龙行星.第1季`。

用户选择转存到 `/我的资源` 时：

| | 转存路径 |
|---|---|
| **期望** | `/我的资源/BBC.恐龙行星.第1季` |
| **实际（修复前）** | `/我的资源/整理清晰纪录片合集/01.BBC英国广播公司/K/BBC.恐龙行星.第1季` |

其中 `整理清晰纪录片合集/01.BBC英国广播公司/K` 是分享者自己网盘中的目录结构，不应出现在转存路径中。

## 原因分析

百度 `list_share_files`（root=1）API 返回的文件路径包含分享者的完整目录结构：

```
path: "/纪录片群合集（❤）/整理清晰纪录片合集/01.BBC英国广播公司/K/BBC.恐龙行星.第1季"
```

`infer_share_root` 原先只取路径第一段 `/纪录片群合集（❤）` 作为 share_root，剩余的中间目录 `整理清晰纪录片合集/01.BBC英国广播公司/K` 被当作 `relative_parent` 拼入了转存目标路径。

## 修复方案

将 `infer_share_root` 从「取第一路径段」改为「计算所有文件路径的最长公共父目录」：

- 单文件/单目录场景：公共父目录 = 完整父路径，`relative_parent` 为空，文件直接转存到 `save_path`
- 多目录场景（如 `/root/抖音/1.jpg` + `/root/微信/2.jpg`）：公共父目录 = `/root`，保留 `抖音`、`微信` 子目录结构

### 修复前后日志对比

**修复前：**
```
share_root=/纪录片群合集（❤）
转存批次 1/1: 1 个文件 -> /我的资源/整理清晰纪录片合集/01.BBC英国广播公司/K
```

**修复后：**
```
share_root=/纪录片群合集（❤）/整理清晰纪录片合集/01.BBC英国广播公司/K
转存批次 1/1: 1 个文件 -> /我的资源 (原始父目录=<root>)
```

百度转存 API 响应确认路径正确：
```json
{"from": "/BBC.恐龙行星.第1季", "to": "/测试转存路径修复/BBC.恐龙行星.第1季"}
```

## 测试

- 单元测试全部通过
- 已在开发环境实际验证转存路径正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)