### PR TITLE
feat: 文件管理页面添加批量删除功能

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -292,6 +292,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/files", get(handlers::get_file_list))
         .route("/files/download", get(handlers::get_download_url))
         .route("/files/folder", post(handlers::create_folder))
+        .route("/files/delete", post(handlers::delete_files))
         // 下载API
         .route("/downloads", post(handlers::create_download))
         .route("/downloads", get(handlers::get_all_downloads))

--- a/backend/src/server/handlers/file.rs
+++ b/backend/src/server/handlers/file.rs
@@ -321,6 +321,104 @@ pub async fn get_download_url(
     }
 }
 
+/// 删除文件请求体
+#[derive(Debug, Deserialize)]
+pub struct DeleteFilesRequest {
+    pub paths: Vec<String>,
+}
+
+/// 删除文件响应数据
+#[derive(Debug, Serialize)]
+pub struct DeleteFilesData {
+    pub deleted_count: usize,
+    pub failed_paths: Vec<String>,
+}
+
+/// 删除文件
+///
+/// POST /api/v1/files/delete
+/// Body: { "paths": ["/path/to/file1", "/path/to/file2"] }
+pub async fn delete_files(
+    State(state): State<AppState>,
+    Json(request): Json<DeleteFilesRequest>,
+) -> Result<Json<ApiResponse<DeleteFilesData>>, StatusCode> {
+    info!("API: 删除文件 paths={:?}", request.paths);
+
+    if request.paths.is_empty() {
+        return Ok(Json(ApiResponse::error(400, "路径列表不能为空".to_string())));
+    }
+    if let Some(p) = request.paths.iter().find(|p| !p.starts_with('/')) {
+        return Ok(Json(ApiResponse::error(
+            400,
+            format!("路径必须以 / 开头: {}", p),
+        )));
+    }
+
+    let client_lock = state.netdisk_client.read().await;
+    let client = match client_lock.as_ref() {
+        Some(c) => c,
+        None => {
+            return Ok(Json(ApiResponse::error(
+                401,
+                "未登录或客户端未初始化".to_string(),
+            )));
+        }
+    };
+
+    match client.delete_files(&request.paths).await {
+        Ok(response) => {
+            if response.success {
+                // 百度异步删除，等待1秒让服务端完成处理，避免前端刷新时文件仍在
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                info!("成功删除 {} 个文件", response.deleted_count);
+                Ok(Json(ApiResponse::success(DeleteFilesData {
+                    deleted_count: response.deleted_count,
+                    failed_paths: response.failed_paths,
+                })))
+            } else {
+                let msg = response.error.unwrap_or_else(|| "删除失败".to_string());
+                Ok(Json(ApiResponse::error(500, msg)))
+            }
+        }
+        Err(e) => {
+            let error_msg = e.to_string();
+            if error_msg.contains("errno=-6") {
+                warn!("删除文件遇到 errno=-6，触发预热重试...");
+                match state.trigger_warmup().await {
+                    Ok(true) => {
+                        let client = state.netdisk_client.read().await;
+                        if let Some(ref c) = *client {
+                            match c.delete_files(&request.paths).await {
+                                Ok(response) if response.success => {
+                                    return Ok(Json(ApiResponse::success(DeleteFilesData {
+                                        deleted_count: response.deleted_count,
+                                        failed_paths: response.failed_paths,
+                                    })));
+                                }
+                                Ok(response) => {
+                                    let msg = response.error.unwrap_or_else(|| "删除失败".to_string());
+                                    return Ok(Json(ApiResponse::error(500, msg)));
+                                }
+                                Err(retry_err) => {
+                                    error!("预热重试后仍失败: {}", retry_err);
+                                    return Ok(Json(ApiResponse::error(
+                                        500,
+                                        format!("删除文件失败（已重试）: {}", retry_err),
+                                    )));
+                                }
+                            }
+                        }
+                    }
+                    Ok(false) => warn!("预热跳过（用户未登录）"),
+                    Err(warmup_err) => error!("预热失败: {}", warmup_err),
+                }
+            }
+            error!("删除文件失败: {}", e);
+            Ok(Json(ApiResponse::error(500, format!("删除文件失败: {}", e))))
+        }
+    }
+}
+
 /// 创建文件夹请求体
 #[derive(Debug, Deserialize)]
 pub struct CreateFolderRequest {

--- a/frontend/src/api/file.ts
+++ b/frontend/src/api/file.ts
@@ -116,6 +116,26 @@ export async function createFolder(path: string): Promise<CreateFolderData> {
   return response.data.data
 }
 
+export interface DeleteFilesData {
+  deleted_count: number
+  failed_paths: string[]
+}
+
+/**
+ * 删除文件
+ */
+export async function deleteFiles(paths: string[]): Promise<DeleteFilesData> {
+  const response = await apiClient.post<ApiResponse<DeleteFilesData>>('/files/delete', {
+    paths
+  })
+
+  if (response.data.code !== 0 || !response.data.data) {
+    throw new Error(response.data.message || '删除文件失败')
+  }
+
+  return response.data.data
+}
+
 // 重新导出共享工具函数，保持向后兼容
 export const formatFileSize = sharedFormatFileSize
 export const formatTime = formatTimestamp

--- a/frontend/src/views/FilesView.vue
+++ b/frontend/src/views/FilesView.vue
@@ -37,6 +37,15 @@
           <el-icon><Link /></el-icon>
           分享 ({{ selectedFiles.length }})
         </el-button>
+        <el-button
+            v-if="selectedFiles.length > 0"
+            type="danger"
+            :loading="batchDeleting"
+            @click="handleBatchDelete"
+        >
+          <el-icon><Delete /></el-icon>
+          删除 ({{ selectedFiles.length }})
+        </el-button>
         <el-button type="primary" @click="showCreateFolderDialog">
           <el-icon><FolderAdd /></el-icon>
           新建文件夹
@@ -77,6 +86,16 @@
             @click="handleBatchShare"
         >
           <el-icon><Link /></el-icon>
+        </el-button>
+        <el-button
+            v-if="selectedFiles.length > 0"
+            type="danger"
+            circle
+            :loading="batchDeleting"
+            @click="handleBatchDelete"
+            title="删除"
+        >
+          <el-icon><Delete /></el-icon>
         </el-button>
         <el-button type="primary" circle @click="showCreateFolderDialog">
           <el-icon><FolderAdd /></el-icon>
@@ -321,8 +340,8 @@
 
 <script setup lang="ts">
 import {ref, onMounted, computed} from 'vue'
-import {ElMessage} from 'element-plus'
-import {getFileList, formatFileSize, formatTime, createFolder, type FileItem} from '@/api/file'
+import {ElMessage, ElMessageBox} from 'element-plus'
+import {getFileList, formatFileSize, formatTime, createFolder, deleteFiles, type FileItem} from '@/api/file'
 import {useIsMobile} from '@/utils/responsive'
 import {createDownload, createFolderDownload, createBatchDownload, type BatchDownloadItem, type DownloadConflictStrategy} from '@/api/download'
 import {createUpload, createFolderUpload, type UploadConflictStrategy} from '@/api/upload'
@@ -372,6 +391,7 @@ const showFilePicker = ref(false)
 const selectedFiles = ref<FileItem[]>([])
 const showDownloadPicker = ref(false)
 const batchDownloading = ref(false)
+const batchDeleting = ref(false)
 
 // 单文件下载（支持 ask_each_time）
 const pendingDownloadFile = ref<FileItem | null>(null)
@@ -1024,6 +1044,46 @@ function handleBatchShare() {
   showShareDialog.value = true
 }
 
+async function handleBatchDelete() {
+  if (selectedFiles.value.length === 0) return
+  const count = selectedFiles.value.length
+  const paths = selectedFiles.value.map(f => f.path)
+  try {
+    await ElMessageBox.confirm(
+      `确定要删除选中的 ${count} 个文件/文件夹吗？删除后可在回收站找回。`,
+      '确认删除',
+      {
+        confirmButtonText: '删除',
+        cancelButtonText: '取消',
+        type: 'warning',
+        beforeClose: async (action, instance, done) => {
+          if (action !== 'confirm') { done(); return }
+          instance.confirmButtonLoading = true
+          instance.confirmButtonText = '删除中...'
+          try {
+            const result = await deleteFiles(paths)
+            done()
+            if (result.failed_paths.length > 0) {
+              ElMessage.warning(`成功删除 ${result.deleted_count} 个，失败 ${result.failed_paths.length} 个`)
+            } else {
+              ElMessage.success(`成功删除 ${result.deleted_count} 个文件/文件夹`)
+            }
+            selectedFiles.value = []
+            await refreshFileList()
+          } catch (error: any) {
+            done()
+            ElMessage.error(error.message || '删除失败')
+          } finally {
+            instance.confirmButtonLoading = false
+          }
+        }
+      }
+    )
+  } catch {
+    // 用户取消
+  }
+}
+
 // 分享成功处理
 function handleShareSuccess() {
   // 清空选择
@@ -1043,7 +1103,7 @@ function handleShareDirectDownloadSuccess(taskId: string) {
 
 <script lang="ts">
 // 图标导入
-export {Folder, Document, Refresh, HomeFilled, Upload, ArrowDown, FolderAdd, Download, Share, Loading, Link} from '@element-plus/icons-vue'
+export {Folder, Document, Refresh, HomeFilled, Upload, ArrowDown, FolderAdd, Download, Share, Loading, Link, Delete} from '@element-plus/icons-vue'
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## 功能描述

在 /files 页面添加批量删除选中文件/文件夹的功能。

## 改动内容

### 后端
- 新增 `POST /api/v1/files/delete` 接口，接收 `{ paths: ["/path1", "/path2"] }`
- 调用已有的 `client.delete_files()` 百度删除 API
- 删除成功后延迟 1 秒返回，等待百度异步处理完成，避免前端刷新时文件仍在
- 支持 errno=-6 预热重试（与 create_folder 一致）

### 前端
- 选中文件后在工具栏显示红色「删除」按钮（PC 端和移动端），与「批量下载」「分享」按钮行为一致
- 点击后弹出确认弹窗，弹窗在 API 返回前保持打开，按钮显示"删除中..." loading 状态
- 删除成功后自动清空选择并刷新文件列表
- 支持部分失败提示

## 涉及文件

- `backend/src/server/handlers/file.rs` — 新增 delete_files handler
- `backend/src/main.rs` — 注册路由
- `frontend/src/api/file.ts` — 新增 deleteFiles API
- `frontend/src/views/FilesView.vue` — 添加删除按钮、确认弹窗、处理逻辑

## 测试

- 选中单个/多个文件和文件夹，确认删除后文件从列表消失
- 取消弹窗不会触发删除
- 删除期间弹窗保持打开并显示 loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)