### PR TITLE
feat: 新增「本地文件」页面，支持浏览和删除本地下载目录

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -367,6 +367,9 @@ async fn main() -> anyhow::Result<()> {
         .route("/fs/goto", get(handlers::goto_path))
         .route("/fs/validate", get(handlers::validate_path))
         .route("/fs/roots", get(handlers::get_roots))
+        // 本地文件API
+        .route("/local-files", get(handlers::local_files::list_local_files))
+        .route("/local-files/delete", post(handlers::local_files::delete_local_files))
         // 配置API
         .route("/config", get(handlers::get_config))
         .route("/config", put(handlers::update_config))

--- a/backend/src/server/handlers/local_files.rs
+++ b/backend/src/server/handlers/local_files.rs
@@ -1,0 +1,146 @@
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info};
+
+use crate::filesystem::{
+    FilesystemConfig, FilesystemService, ListRequest, ListResponse, SortField, SortOrder,
+};
+use crate::server::handlers::ApiResponse;
+use crate::server::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct LocalFileListQuery {
+    #[serde(default)]
+    pub path: String,
+    #[serde(default)]
+    pub page: usize,
+    #[serde(default = "default_page_size")]
+    pub page_size: usize,
+    #[serde(default)]
+    pub sort_field: SortField,
+    #[serde(default)]
+    pub sort_order: SortOrder,
+}
+
+fn default_page_size() -> usize {
+    100
+}
+
+pub async fn list_local_files(
+    State(state): State<AppState>,
+    Query(query): Query<LocalFileListQuery>,
+) -> Result<Json<ApiResponse<ListResponse>>, StatusCode> {
+    let download_dir = state
+        .config
+        .read()
+        .await
+        .download
+        .download_dir
+        .canonicalize()
+        .unwrap_or_else(|_| state.config.blocking_read().download.download_dir.clone());
+
+    let download_dir_str = download_dir.to_string_lossy().to_string();
+
+    let service = FilesystemService::new(FilesystemConfig {
+        allowed_paths: vec![download_dir_str.clone()],
+        default_path: Some(download_dir_str.clone()),
+        ..Default::default()
+    });
+
+    let list_path = if query.path.is_empty() {
+        download_dir_str
+    } else {
+        query.path.clone()
+    };
+
+    let req = ListRequest {
+        path: list_path,
+        page: query.page,
+        page_size: query.page_size,
+        sort_field: query.sort_field,
+        sort_order: query.sort_order,
+    };
+
+    match service.list_directory(&req) {
+        Ok(response) => Ok(Json(ApiResponse::success(response))),
+        Err(e) => {
+            error!("列出本地文件失败: {}", e);
+            Ok(Json(ApiResponse::error(500, format!("列出本地文件失败: {}", e))))
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DeleteLocalFilesRequest {
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeleteLocalFilesData {
+    pub deleted_count: usize,
+    pub failed_paths: Vec<String>,
+}
+
+pub async fn delete_local_files(
+    State(state): State<AppState>,
+    Json(request): Json<DeleteLocalFilesRequest>,
+) -> Result<Json<ApiResponse<DeleteLocalFilesData>>, StatusCode> {
+    info!("API: 删除本地文件 paths={:?}", request.paths);
+
+    if request.paths.is_empty() {
+        return Ok(Json(ApiResponse::error(400, "路径列表不能为空".to_string())));
+    }
+
+    let download_dir = state
+        .config
+        .read()
+        .await
+        .download
+        .download_dir
+        .canonicalize()
+        .unwrap_or_else(|_| state.config.blocking_read().download.download_dir.clone());
+
+    let mut deleted_count = 0usize;
+    let mut failed_paths = Vec::new();
+
+    for path_str in &request.paths {
+        let path = std::path::Path::new(path_str);
+        let canonical = match path.canonicalize() {
+            Ok(p) => p,
+            Err(_) => {
+                failed_paths.push(path_str.clone());
+                continue;
+            }
+        };
+
+        if !canonical.starts_with(&download_dir) {
+            error!("路径不在下载目录内: {}", path_str);
+            failed_paths.push(path_str.clone());
+            continue;
+        }
+
+        let result = if canonical.is_dir() {
+            std::fs::remove_dir_all(&canonical)
+        } else {
+            std::fs::remove_file(&canonical)
+        };
+
+        match result {
+            Ok(()) => deleted_count += 1,
+            Err(e) => {
+                error!("删除失败 {}: {}", path_str, e);
+                failed_paths.push(path_str.clone());
+            }
+        }
+    }
+
+    info!("本地文件删除完成: 成功={}, 失败={}", deleted_count, failed_paths.len());
+    Ok(Json(ApiResponse::success(DeleteLocalFilesData {
+        deleted_count,
+        failed_paths,
+    })))
+}

--- a/backend/src/server/handlers/mod.rs
+++ b/backend/src/server/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod download;
 pub mod encryption_export;
 pub mod file;
 pub mod filesystem;
+pub mod local_files;
 pub mod folder_download;
 pub mod share;
 pub mod transfer;

--- a/frontend/src/api/localFiles.ts
+++ b/frontend/src/api/localFiles.ts
@@ -1,0 +1,57 @@
+import axios from 'axios'
+import type { ApiResponse, FileEntry, ListDirectoryResponse, SortField, SortOrder } from './filesystem'
+
+const WEB_AUTH_ACCESS_TOKEN_KEY = 'web_auth_access_token'
+
+const apiClient = axios.create({
+  baseURL: '/api/v1',
+  timeout: 30000,
+})
+
+apiClient.interceptors.request.use(
+    (config) => {
+      const token = localStorage.getItem(WEB_AUTH_ACCESS_TOKEN_KEY)
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`
+      }
+      return config
+    },
+    (error) => Promise.reject(error)
+)
+
+export type { FileEntry, ListDirectoryResponse, SortField, SortOrder }
+
+export interface DeleteLocalFilesData {
+  deleted_count: number
+  failed_paths: string[]
+}
+
+export async function listLocalFiles(
+    path: string = '',
+    page: number = 0,
+    pageSize: number = 100,
+    sortField: SortField = 'name',
+    sortOrder: SortOrder = 'asc'
+): Promise<ListDirectoryResponse> {
+  const response = await apiClient.get<ApiResponse<ListDirectoryResponse>>('/local-files', {
+    params: { path, page, page_size: pageSize, sort_field: sortField, sort_order: sortOrder }
+  })
+
+  if (response.data.code !== 0 || !response.data.data) {
+    throw new Error(response.data.message || '获取本地文件列表失败')
+  }
+
+  return response.data.data
+}
+
+export async function deleteLocalFiles(paths: string[]): Promise<DeleteLocalFilesData> {
+  const response = await apiClient.post<ApiResponse<DeleteLocalFilesData>>('/local-files/delete', {
+    paths
+  })
+
+  if (response.data.code !== 0 || !response.data.data) {
+    throw new Error(response.data.message || '删除本地文件失败')
+  }
+
+  return response.data.data
+}

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -20,7 +20,12 @@
       >
         <el-menu-item index="/files">
           <el-icon><Files /></el-icon>
-          <template #title>文件管理</template>
+          <template #title>网盘管理</template>
+        </el-menu-item>
+
+        <el-menu-item index="/local">
+          <el-icon><Folder /></el-icon>
+          <template #title>本地文件</template>
         </el-menu-item>
 
         <el-menu-item index="/downloads">
@@ -94,7 +99,12 @@
         >
           <el-menu-item index="/files">
             <el-icon><Files /></el-icon>
-            <span>文件管理</span>
+            <span>网盘管理</span>
+          </el-menu-item>
+
+          <el-menu-item index="/local">
+            <el-icon><Folder /></el-icon>
+            <span>本地文件</span>
           </el-menu-item>
 
           <el-menu-item index="/downloads">
@@ -241,6 +251,7 @@ import { useIsMobile } from '@/utils/responsive'
 import UserProfileDialog from '@/components/UserProfileDialog.vue'
 import {
   FolderOpened,
+  Folder,
   Files,
   Download,
   Upload,
@@ -286,7 +297,8 @@ const userAvatar = computed(() => authStore.avatar)
 
 const pageTitle = computed(() => {
   const titles: Record<string, string> = {
-    '/files': '文件管理',
+    '/files': '网盘管理',
+    '/local': '本地文件',
     '/downloads': '下载管理',
     '/uploads': '上传管理',
     '/transfers': '转存管理',

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -29,7 +29,13 @@ const routes: RouteRecordRaw[] = [
         path: '/files',
         name: 'Files',
         component: () => import('@/views/FilesView.vue'),
-        meta: { title: '文件管理' }
+        meta: { title: '网盘管理' }
+      },
+      {
+        path: '/local',
+        name: 'LocalFiles',
+        component: () => import('@/views/LocalFilesView.vue'),
+        meta: { title: '本地文件' }
       },
       {
         path: '/downloads',

--- a/frontend/src/views/LocalFilesView.vue
+++ b/frontend/src/views/LocalFilesView.vue
@@ -1,0 +1,458 @@
+<template>
+  <div class="files-container" :class="{ 'is-mobile': isMobile }">
+    <!-- 面包屑导航 -->
+    <div class="breadcrumb-bar">
+      <el-breadcrumb separator="/">
+        <el-breadcrumb-item @click="navigateToDir('')">
+          <el-icon>
+            <HomeFilled/>
+          </el-icon>
+          <span v-if="!isMobile">下载目录</span>
+        </el-breadcrumb-item>
+        <el-breadcrumb-item
+            v-for="(part, index) in pathParts"
+            :key="index"
+            @click="navigateToDir(getPathUpTo(index))"
+        >
+          {{ part }}
+        </el-breadcrumb-item>
+      </el-breadcrumb>
+
+      <!-- PC端工具栏 -->
+      <div v-if="!isMobile" class="toolbar-buttons">
+        <el-button
+            v-if="selectedFiles.length > 0"
+            type="danger"
+            :loading="batchDeleting"
+            @click="handleBatchDelete"
+        >
+          <el-icon><Delete /></el-icon>
+          删除 ({{ selectedFiles.length }})
+        </el-button>
+        <el-button type="primary" @click="refreshFileList">
+          <el-icon><Refresh /></el-icon>
+          刷新
+        </el-button>
+      </div>
+
+      <!-- 移动端工具栏 -->
+      <div v-else class="toolbar-buttons-mobile">
+        <el-button
+            v-if="selectedFiles.length > 0"
+            type="danger"
+            circle
+            :loading="batchDeleting"
+            @click="handleBatchDelete"
+        >
+          <el-icon><Delete /></el-icon>
+        </el-button>
+        <el-button type="primary" circle @click="refreshFileList">
+          <el-icon><Refresh /></el-icon>
+        </el-button>
+      </div>
+    </div>
+
+    <!-- 文件列表 -->
+    <div class="file-list" ref="fileListRef" @scroll="handleScroll">
+      <!-- PC端表格视图 -->
+      <el-table
+          v-if="!isMobile"
+          v-loading="loading"
+          :data="fileList"
+          style="width: 100%"
+          @row-click="handleRowClick"
+          @selection-change="handleSelectionChange"
+          :row-class-name="getRowClassName"
+      >
+        <el-table-column type="selection" width="55" />
+        <el-table-column label="文件名" min-width="400">
+          <template #default="{ row }">
+            <div class="file-name">
+              <el-icon :size="20" class="file-icon">
+                <Folder v-if="row.entryType === 'directory'"/>
+                <Document v-else/>
+              </el-icon>
+              <span>{{ row.name }}</span>
+            </div>
+          </template>
+        </el-table-column>
+
+        <el-table-column label="大小" width="120">
+          <template #default="{ row }">
+            <span v-if="row.entryType === 'file'">{{ formatFileSize(row.size) }}</span>
+            <span v-else>-</span>
+          </template>
+        </el-table-column>
+
+        <el-table-column label="修改时间" width="180">
+          <template #default="{ row }">
+            {{ formatTime(row.updatedAt) }}
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <!-- 移动端卡片视图 -->
+      <div v-else class="mobile-file-list" v-loading="loading">
+        <div
+            v-for="item in fileList"
+            :key="item.id"
+            class="mobile-file-card"
+            :class="{ 'is-folder': item.entryType === 'directory' }"
+            @click="handleRowClick(item)"
+        >
+          <div class="file-card-main">
+            <el-icon :size="36" class="file-card-icon" :color="item.entryType === 'directory' ? '#e6a23c' : '#409eff'">
+              <Folder v-if="item.entryType === 'directory'"/>
+              <Document v-else/>
+            </el-icon>
+            <div class="file-card-info">
+              <div class="file-card-name">{{ item.name }}</div>
+              <div class="file-card-meta">
+                <span v-if="item.entryType === 'file'">{{ formatFileSize(item.size) }}</span>
+                <span v-else>文件夹</span>
+                <span class="meta-divider">·</span>
+                <span>{{ formatTime(item.updatedAt) }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 加载更多提示 -->
+      <div v-if="loadingMore" class="loading-more">
+        <el-icon class="is-loading"><Loading /></el-icon>
+        <span>加载中...</span>
+      </div>
+      <div v-else-if="!hasMore && fileList.length > 0" class="no-more">
+        没有更多了
+      </div>
+
+      <!-- 空状态 -->
+      <el-empty v-if="!loading && fileList.length === 0" description="当前目录为空"/>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { listLocalFiles, deleteLocalFiles, type FileEntry } from '@/api/localFiles'
+import { formatFileSize, formatTime } from '@/api/filesystem'
+import { useIsMobile } from '@/utils/responsive'
+
+const isMobile = useIsMobile()
+
+const loading = ref(false)
+const loadingMore = ref(false)
+const fileList = ref<FileEntry[]>([])
+const currentPath = ref('')
+const rootPath = ref('')
+const currentPage = ref(0)
+const hasMore = ref(true)
+const fileListRef = ref<HTMLElement | null>(null)
+const selectedFiles = ref<FileEntry[]>([])
+const batchDeleting = ref(false)
+
+const pathParts = computed(() => {
+  if (!currentPath.value || currentPath.value === rootPath.value) return []
+  const relative = currentPath.value.startsWith(rootPath.value)
+      ? currentPath.value.slice(rootPath.value.length)
+      : currentPath.value
+  return relative.split('/').filter(p => p)
+})
+
+function getPathUpTo(index: number): string {
+  const parts = pathParts.value.slice(0, index + 1)
+  return rootPath.value + '/' + parts.join('/')
+}
+
+async function loadFiles(path: string, append: boolean = false) {
+  if (append) {
+    loadingMore.value = true
+  } else {
+    loading.value = true
+    currentPage.value = 0
+    hasMore.value = true
+  }
+
+  try {
+    const page = append ? currentPage.value : 0
+    const data = await listLocalFiles(path, page, 100)
+
+    if (append) {
+      fileList.value = [...fileList.value, ...data.entries]
+    } else {
+      fileList.value = data.entries
+      currentPath.value = data.currentPath
+      if (!rootPath.value) {
+        rootPath.value = data.currentPath
+      }
+    }
+
+    hasMore.value = data.hasMore
+    currentPage.value = data.page
+  } catch (error: any) {
+    ElMessage.error(error.message || '加载本地文件列表失败')
+  } finally {
+    loading.value = false
+    loadingMore.value = false
+  }
+}
+
+async function loadNextPage() {
+  if (loadingMore.value || !hasMore.value) return
+  currentPage.value++
+  await loadFiles(currentPath.value, true)
+}
+
+function handleScroll(event: Event) {
+  const target = event.target as HTMLElement
+  const { scrollTop, scrollHeight, clientHeight } = target
+  if (scrollHeight - scrollTop - clientHeight < 100) {
+    loadNextPage()
+  }
+}
+
+function navigateToDir(path: string) {
+  loadFiles(path || '')
+}
+
+function refreshFileList() {
+  loadFiles(currentPath.value || '')
+}
+
+function handleRowClick(row: FileEntry) {
+  if (row.entryType === 'directory') {
+    navigateToDir(row.path)
+  }
+}
+
+function getRowClassName({ row }: { row: FileEntry }) {
+  return row.entryType === 'directory' ? 'directory-row' : ''
+}
+
+function handleSelectionChange(selection: FileEntry[]) {
+  selectedFiles.value = selection
+}
+
+async function handleBatchDelete() {
+  if (selectedFiles.value.length === 0) return
+  const count = selectedFiles.value.length
+  const paths = selectedFiles.value.map(f => f.path)
+  try {
+    await ElMessageBox.confirm(
+        `确定要删除选中的 ${count} 个文件/文件夹吗？此操作不可恢复！`,
+        '确认删除',
+        {
+          confirmButtonText: '删除',
+          cancelButtonText: '取消',
+          type: 'warning',
+          beforeClose: async (action, instance, done) => {
+            if (action !== 'confirm') { done(); return }
+            instance.confirmButtonLoading = true
+            instance.confirmButtonText = '删除中...'
+            try {
+              const result = await deleteLocalFiles(paths)
+              done()
+              if (result.failed_paths.length > 0) {
+                ElMessage.warning(`成功删除 ${result.deleted_count} 个，失败 ${result.failed_paths.length} 个`)
+              } else {
+                ElMessage.success(`成功删除 ${result.deleted_count} 个文件/文件夹`)
+              }
+              selectedFiles.value = []
+              await refreshFileList()
+            } catch (error: any) {
+              done()
+              ElMessage.error(error.message || '删除失败')
+            } finally {
+              instance.confirmButtonLoading = false
+            }
+          }
+        }
+    )
+  } catch {
+    // 用户取消
+  }
+}
+
+onMounted(() => {
+  loadFiles('')
+})
+</script>
+
+<script lang="ts">
+export { Folder, Document, Refresh, HomeFilled, Loading, Delete } from '@element-plus/icons-vue'
+</script>
+
+<style scoped lang="scss">
+.files-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: white;
+}
+
+.breadcrumb-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid #e0e0e0;
+  background: white;
+  gap: 12px;
+
+  .toolbar-buttons {
+    display: flex;
+    gap: 12px;
+    flex-shrink: 0;
+  }
+
+  .toolbar-buttons-mobile {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+}
+
+.file-list {
+  flex: 1;
+  padding: 20px;
+  overflow: auto;
+}
+
+.loading-more {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  color: #909399;
+  font-size: 14px;
+}
+
+.no-more {
+  text-align: center;
+  padding: 16px;
+  color: #c0c4cc;
+  font-size: 14px;
+}
+
+.file-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+
+  .file-icon {
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    color: #409eff;
+  }
+}
+
+:deep(.directory-row) {
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5f7fa;
+  }
+}
+
+:deep(.el-table__row) {
+  &:hover .file-name {
+    color: #409eff;
+  }
+}
+
+.is-mobile {
+  height: calc(100vh - 60px - 56px);
+
+  .breadcrumb-bar {
+    padding: 12px 16px;
+    flex-wrap: wrap;
+  }
+
+  .file-list {
+    padding: 12px;
+  }
+}
+
+.mobile-file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mobile-file-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: #f9f9f9;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:active {
+    background: #f0f0f0;
+    transform: scale(0.98);
+  }
+
+  &.is-folder {
+    background: #fffbf0;
+
+    &:active {
+      background: #fff3d9;
+    }
+  }
+
+  .file-card-main {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .file-card-icon {
+    flex-shrink: 0;
+  }
+
+  .file-card-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .file-card-name {
+    font-size: 15px;
+    font-weight: 500;
+    color: #333;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 4px;
+  }
+
+  .file-card-meta {
+    font-size: 12px;
+    color: #909399;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+
+    .meta-divider {
+      color: #dcdfe6;
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  :deep(.el-dialog) {
+    width: 92% !important;
+    margin: 5vh auto !important;
+  }
+}
+</style>

--- a/frontend/src/views/UploadsView.vue
+++ b/frontend/src/views/UploadsView.vue
@@ -51,7 +51,7 @@
         <template #description>
           <p>暂无上传任务</p>
           <p style="font-size: 12px; color: #909399;">
-            前往「文件管理」页面点击"上传"按钮
+            前往「网盘管理」页面点击"上传"按钮
           </p>
         </template>
       </el-empty>


### PR DESCRIPTION
## 概述

新增「本地文件」菜单页面，用户可在 Web 界面中浏览和管理服务器本地下载目录中的文件，与「网盘管理」（百度云端文件）形成对应。

## 改动内容

- **后端**：新增 `GET /api/v1/local-files` 和 `POST /api/v1/local-files/delete` 接口，复用现有 `FilesystemService`，通过 `allowed_paths` 白名单限定访问范围为配置的下载目录，防止路径穿越
- **前端**：新增 `LocalFilesView` 页面（PC 表格视图 + 移动端卡片视图），支持目录浏览、面包屑导航、批量选择删除
- 侧边栏及移动端抽屉菜单新增「本地文件」入口（位于「网盘管理」下方）
- 「文件管理」重命名为「网盘管理」，以区分云端文件和本地文件

## 测试计划

- [x] 点击侧边栏「本地文件」，确认页面正常加载并显示下载目录内容
- [x] 点击文件夹进入子目录，面包屑导航正确更新，可返回上级
- [x] 勾选文件/文件夹后批量删除，确认删除成功并刷新列表
- [x] 尝试删除下载目录外的路径，确认被拒绝（路径穿越防护）
- [x] 移动端抽屉菜单中「本地文件」入口正常可用
- [x] 「网盘管理」页面功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)